### PR TITLE
style: adjust visualization dimensions and font sizes for better readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
 
 
             // --- D3.js Visualization Logic ---
-            const width = 800;
+            const width = 900;
             const height = 600;
 
             // 1. Prepare the data for D3
@@ -129,7 +129,7 @@
             const links = [];
             const categories = {};
 
-            const rootNode = { id: 'AI System', type: 'root', fx: width / 2, fy: height / 2 };
+            const rootNode = { id: 'AI System', type: 'root', fx: width / 1.5, fy: height / 1.5 };
             nodes.push(rootNode);
 
             matrixData.forEach(item => {
@@ -188,7 +188,7 @@
                 .attr("y", d => d.type === 'root' ? 0 : 5)
                 .attr("text-anchor", d => d.type === 'root' ? 'middle' : 'start')
                 .attr("alignment-baseline", "middle")
-                .style("font-size", d => d.type === 'root' ? "16px" : (d.type === 'category' ? "14px" : "11px"))
+                .style("font-size", d => d.type === 'root' ? "14px" : (d.type === 'category' ? "14px" : "11px"))
                 .style("font-weight", d => d.type === 'root' || d.type === 'category' ? "600" : "400")
                 .attr("fill", d => d.type === 'root' ? "white" : "#334155");
 


### PR DESCRIPTION
This pull request makes adjustments to the D3.js visualization in `index.html` to improve layout and readability. The key changes include resizing the visualization canvas and modifying text styling for better visual hierarchy.

Visualization layout adjustments:
* Increased the canvas width from 800 to 900 pixels and adjusted the root node's fixed position to align better with the new dimensions. (`[index.htmlL124-R132](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L124-R132)`)

Text styling improvements:
* Reduced the font size for the root node from 16px to 14px to create a more balanced text hierarchy. (`[index.htmlL191-R191](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L191-R191)`)