### PR TITLE
refactor: extract root node position variables for easier customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,12 +124,16 @@
             const width = 800;
             const height = 600;
 
+            // Root node positioning can be easily adjusted here
+            const rootNodeX = width / 2;
+            const rootNodeY = height / 2;
+
             // 1. Prepare the data for D3
             const nodes = [];
             const links = [];
             const categories = {};
 
-            const rootNode = { id: 'AI System', type: 'root', fx: width / 2, fy: height / 2 };
+            const rootNode = { id: 'AI System', type: 'root', fx: rootNodeX, fy: rootNodeY };
             nodes.push(rootNode);
 
             matrixData.forEach(item => {


### PR DESCRIPTION
Fixes #5 

This pull request introduces a small refactor to improve the readability and flexibility of the root node positioning logic in the D3 visualization setup.

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R127-R136): Introduced `rootNodeX` and `rootNodeY` variables to make the root node's position (`fx`, `fy`) more easily adjustable, replacing the inline calculations.